### PR TITLE
Fix WordPress capitalization in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Wordpress - ignore core, configuration, examples, uploads and logs.
+# WordPress - ignore core, configuration, examples, uploads and logs.
 # https://github.com/github/gitignore/blob/main/WordPress.gitignore
 
 # Core


### PR DESCRIPTION
## Summary
- correct "Wordpress" capitalization in `.gitignore`

## Testing
- `npm test` *(fails: could not find package.json)*
- `make test` *(fails: no rule for target 'test')*

------
https://chatgpt.com/codex/tasks/task_b_683c334f94d0832fb7d3909f74786f97