### PR TITLE
Add basic WordPress starter theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /wp-content/themes/index.php
 /wp-includes/
 /index.php
+!index.php
 /license.txt
 /readme.html
 /wp-*.php

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# wp-website
+# Starter WordPress Theme
+
+This repository contains a minimal starter theme for WordPress.
+
+## Setup locally
+
+1. Clone this repository into the `wp-content/themes` directory of your local WordPress installation.
+
+```bash
+git clone <repo-url> starter-theme
+```
+
+2. Activate **Starter Theme** from the WordPress admin panel.
+
+## Build and upload
+
+To deploy the theme to another WordPress site, create a zip archive and upload it via the WordPress admin interface.
+
+```bash
+zip -r starter-theme.zip * -x .git\* README.md
+```
+
+Upload the generated `starter-theme.zip` file through **Appearance → Themes → Add New → Upload Theme**.
+

--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,7 @@
+<footer class="site-footer">
+    <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></p>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>
+

--- a/functions.php
+++ b/functions.php
@@ -1,0 +1,11 @@
+<?php
+function starter_theme_setup() {
+    add_theme_support( 'title-tag' );
+}
+add_action( 'after_setup_theme', 'starter_theme_setup' );
+
+function starter_theme_scripts() {
+    wp_enqueue_style( 'starter-theme-style', get_stylesheet_uri() );
+}
+add_action( 'wp_enqueue_scripts', 'starter_theme_scripts' );
+

--- a/header.php
+++ b/header.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html <?php language_attributes(); ?> >
+<head>
+    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<header class="site-header">
+    <h1 class="site-title"><a href="<?php echo esc_url( home_url('/') ); ?>"><?php bloginfo('name'); ?></a></h1>
+</header>
+

--- a/index.php
+++ b/index.php
@@ -1,0 +1,18 @@
+<?php get_header(); ?>
+
+<div id="content" class="site-content">
+    <?php
+    if ( have_posts() ) :
+        while ( have_posts() ) :
+            the_post();
+            the_content();
+        endwhile;
+    else :
+        echo '<p>No content found.</p>';
+    endif;
+    ?>
+</div>
+
+<?php get_sidebar(); ?>
+<?php get_footer(); ?>
+

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,0 +1,6 @@
+<aside class="sidebar">
+    <?php if ( is_active_sidebar( 'primary' ) ) : ?>
+        <?php dynamic_sidebar( 'primary' ); ?>
+    <?php endif; ?>
+</aside>
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,14 @@
+/*
+Theme Name: Starter Theme
+Theme URI: https://example.com/
+Author: Example Author
+Author URI: https://example.com/
+Description: A basic starter WordPress theme.
+Version: 1.0
+License: MIT
+License URI: https://opensource.org/licenses/MIT
+Text Domain: starter-theme
+*/
+
+body { margin: 0; }
+


### PR DESCRIPTION
## Summary
- add minimal starter theme files directly in project root
- document how to set up and package the theme
- adjust `.gitignore` so `index.php` is included

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683c3512bed8832f9a2311666d4f84b9