### PR TITLE
Add responsive front page template

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,5 +1,10 @@
 <footer class="site-footer">
     <p>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></p>
+    <p class="social">
+        <a href="#">Facebook</a> |
+        <a href="#">Twitter</a> |
+        <a href="#">Instagram</a>
+    </p>
 </footer>
 <?php wp_footer(); ?>
 </body>

--- a/functions.php
+++ b/functions.php
@@ -1,11 +1,24 @@
 <?php
 function starter_theme_setup() {
+    // Enable dynamic title tag support.
     add_theme_support( 'title-tag' );
+
+    // Register a primary navigation menu.
+    register_nav_menus( array(
+        'primary' => __( 'Primary Menu', 'starter-theme' ),
+    ) );
 }
 add_action( 'after_setup_theme', 'starter_theme_setup' );
 
 function starter_theme_scripts() {
     wp_enqueue_style( 'starter-theme-style', get_stylesheet_uri() );
+
+    // Only load Swiper on the front page template.
+    if ( is_page_template( 'templates/front-page.php' ) ) {
+        wp_enqueue_style( 'swiper', 'https://unpkg.com/swiper@8/swiper-bundle.min.css', array(), '8' );
+        wp_enqueue_script( 'swiper', 'https://unpkg.com/swiper@8/swiper-bundle.min.js', array(), '8', true );
+        wp_enqueue_script( 'starter-front-page', get_template_directory_uri() . '/js/front-page.js', array( 'swiper' ), '1.0', true );
+    }
 }
 add_action( 'wp_enqueue_scripts', 'starter_theme_scripts' );
 

--- a/header.php
+++ b/header.php
@@ -1,12 +1,22 @@
 <!DOCTYPE html>
-<html <?php language_attributes(); ?> >
+<html <?php language_attributes(); ?>>
 <head>
-    <meta charset="<?php bloginfo('charset'); ?>">
+    <meta charset="<?php bloginfo( 'charset' ); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
 <header class="site-header">
-    <h1 class="site-title"><a href="<?php echo esc_url( home_url('/') ); ?>"><?php bloginfo('name'); ?></a></h1>
+    <div class="header-inner">
+        <h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+        <nav class="site-navigation" aria-label="Primary Menu">
+            <?php
+            wp_nav_menu( array(
+                'theme_location' => 'primary',
+                'menu_class'     => 'menu',
+                'container'      => false,
+            ) );
+            ?>
+        </nav>
+    </div>
 </header>
-

--- a/js/front-page.js
+++ b/js/front-page.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function () {
+    if (typeof Swiper !== 'undefined') {
+        new Swiper('.animal-gallery .swiper', {
+            loop: true,
+            pagination: {
+                el: '.swiper-pagination',
+                clickable: true
+            },
+            navigation: {
+                nextEl: '.swiper-button-next',
+                prevEl: '.swiper-button-prev'
+            }
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -12,3 +12,110 @@ Text Domain: starter-theme
 
 body { margin: 0; }
 
+/* Header styles */
+.site-header {
+    background: #f4f4f4;
+}
+.header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+}
+.site-title {
+    margin: 0;
+    font-size: 1.5rem;
+}
+.site-navigation .menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}
+.site-navigation .menu li {
+    margin-left: 1rem;
+}
+@media (max-width: 600px) {
+    .site-navigation .menu {
+        flex-direction: column;
+    }
+    .site-navigation .menu li {
+        margin: 0.5rem 0;
+    }
+}
+
+/* Hero banner */
+.hero {
+    text-align: center;
+    padding: 4rem 1rem;
+    background: #eee;
+}
+
+/* Offer cards */
+.offers {
+    padding: 2rem 1rem;
+}
+.offer-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+.offer-card {
+    flex: 1 1 calc(25% - 1rem);
+    background: #fafafa;
+    border: 1px solid #ddd;
+    padding: 1rem;
+    text-align: center;
+}
+@media (max-width: 800px) {
+    .offer-card {
+        flex: 1 1 calc(50% - 1rem);
+    }
+}
+@media (max-width: 500px) {
+    .offer-card {
+        flex: 1 1 100%;
+    }
+}
+
+/* Gallery slider */
+.animal-gallery {
+    padding: 2rem 1rem;
+}
+.animal-gallery img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+/* Contact form */
+.contact-us {
+    padding: 2rem 1rem;
+    max-width: 800px;
+    margin: 0 auto;
+}
+.contact-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.contact-form input,
+.contact-form textarea {
+    padding: 0.5rem;
+    width: 100%;
+}
+
+/* Footer */
+.site-footer {
+    background: #f4f4f4;
+    text-align: center;
+    padding: 1rem;
+}
+.site-footer .social a {
+    margin: 0 0.5rem;
+}
+

--- a/templates/front-page.php
+++ b/templates/front-page.php
@@ -1,0 +1,67 @@
+<?php
+/*
+Template Name: Front Page
+*/
+get_header();
+?>
+<main class="front-page">
+    <section class="hero">
+        <h2>Welcome to Our Animal Shelter</h2>
+        <p>We provide loving care and find forever homes for animals in need.</p>
+    </section>
+
+    <section class="offers">
+        <h2>What We Offer</h2>
+        <div class="offer-cards">
+            <div class="offer-card">
+                <h3>Adoption</h3>
+                <p>Find your new best friend.</p>
+            </div>
+            <div class="offer-card">
+                <h3>Volunteer</h3>
+                <p>Help us care for our animals.</p>
+            </div>
+            <div class="offer-card">
+                <h3>Donate</h3>
+                <p>Support our mission.</p>
+            </div>
+            <div class="offer-card">
+                <h3>Foster</h3>
+                <p>Provide a temporary home.</p>
+            </div>
+        </div>
+    </section>
+
+    <section class="animal-gallery">
+        <h2>Meet Our Animals</h2>
+        <div class="swiper">
+            <div class="swiper-wrapper">
+                <div class="swiper-slide"><img src="https://via.placeholder.com/600x400?text=Animal+1" alt="Animal 1"></div>
+                <div class="swiper-slide"><img src="https://via.placeholder.com/600x400?text=Animal+2" alt="Animal 2"></div>
+                <div class="swiper-slide"><img src="https://via.placeholder.com/600x400?text=Animal+3" alt="Animal 3"></div>
+            </div>
+            <div class="swiper-pagination"></div>
+            <div class="swiper-button-prev"></div>
+            <div class="swiper-button-next"></div>
+        </div>
+    </section>
+
+    <section class="contact-us">
+        <h2>Contact Us</h2>
+        <form class="contact-form">
+            <label for="contact-name">Name</label>
+            <input id="contact-name" name="contact-name" type="text" required>
+            <label for="contact-email">Email</label>
+            <input id="contact-email" name="contact-email" type="email" required>
+            <label for="contact-message">Message</label>
+            <textarea id="contact-message" name="contact-message" rows="4" required></textarea>
+            <button type="submit">Send Message</button>
+        </form>
+        <div class="contact-info">
+            <p>123 Shelter Lane, Petville</p>
+            <p>Phone: (555) 123-4567</p>
+            <p>Email: info@example.com</p>
+        </div>
+    </section>
+</main>
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- create a custom `front-page.php` template
- register primary nav menu and enqueue Swiper
- rebuild header with navigation
- style new sections and add footer links
- add JavaScript to initialize Swiper

## Testing
- `php -l templates/front-page.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683d8f7bcd88832fa04fddfb83cea083