### PR TITLE
Adjust mobile burger menu position and color

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,8 +61,15 @@ section {
     margin-left: 1rem;
 }
 @media (max-width: 600px) {
+    .header-inner {
+        justify-content: flex-start;
+    }
     .menu-toggle {
         display: block;
+        margin-left: auto;
+    }
+    .site-navigation .menu a {
+        color: #000;
     }
     .site-navigation {
         position: relative;


### PR DESCRIPTION
## Summary
- align the hamburger icon to the far right on small screens
- make links inside the mobile navigation black

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d969e1e74832fa874e15d267332e5