### PR TITLE
Improve gallery slider responsiveness

### DIFF
--- a/js/front-page.js
+++ b/js/front-page.js
@@ -2,6 +2,11 @@ document.addEventListener('DOMContentLoaded', function () {
     if (typeof Swiper !== 'undefined') {
         new Swiper('.animal-gallery .swiper', {
             loop: true,
+            slidesPerView: 1,
+            autoplay: {
+                delay: 5000,
+                disableOnInteraction: false
+            },
             pagination: {
                 el: '.swiper-pagination',
                 clickable: true

--- a/style.css
+++ b/style.css
@@ -139,12 +139,24 @@ section {
     background: #FFF9F4;
 }
 .animal-gallery img {
-    width: 100%;
-    height: auto;
     display: block;
+    width: auto;
+    max-width: 600px;
+    height: auto;
+    margin: 0 auto;
+    max-height: 400px;
 }
 .animal-gallery .swiper {
     position: relative;
+    overflow: hidden;
+    max-width: 100%;
+    margin: 0 auto;
+}
+@media (max-width: 600px) {
+    .animal-gallery img {
+        max-width: 300px;
+        max-height: 200px;
+    }
 }
 .swiper-button-prev,
 .swiper-button-next {


### PR DESCRIPTION
## Summary
- adjust gallery images to size responsively using media queries
- constrain slider overflow so only one image shows
- enable automatic slide change every 5 seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d98a91460832fb89f8f99dc06f158