### PR TITLE
Add SFTP deploy workflow

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -1,0 +1,30 @@
+name: Deploy Theme
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy via SFTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+        with:
+          server: ${{ secrets.FTP_Host }}
+          username: ${{ secrets.FTP_Username }}
+          password: ${{ secrets.FTP_Password }}
+          protocol: sftp
+          port: ${{ secrets.FTP_Port }}
+          local-dir: ./
+          server-dir: ./
+          exclude: |
+            .git/**
+            .github/**
+            README.md
+            .gitignore
+
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy WordPress theme via SFTP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683d9e5776a0832f80c71a53691d47de