### PR TITLE
Add responsive front page template

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,5 +1,10 @@
-<footer>
+<footer class="site-footer">
     <p>&copy; <?php echo date('Y'); ?> Starter Theme</p>
+    <ul class="social-links">
+        <li><a href="#">Facebook</a></li>
+        <li><a href="#">Twitter</a></li>
+        <li><a href="#">Instagram</a></li>
+    </ul>
 </footer>
 <?php wp_footer(); ?>
 </body>

--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,22 @@
 <?php
 function starter_theme_setup() {
     add_theme_support( 'title-tag' );
+    // Register navigation menu location
+    register_nav_menus( array(
+        'primary' => __( 'Primary Menu', 'starter-theme' ),
+    ) );
 }
 add_action( 'after_setup_theme', 'starter_theme_setup' );
+
+function starter_theme_scripts() {
+    // Main stylesheet
+    wp_enqueue_style( 'starter-style', get_stylesheet_uri() );
+
+    // Swiper slider assets
+    wp_enqueue_style( 'swiper', 'https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css', array(), null );
+    wp_enqueue_script( 'swiper', 'https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js', array(), null, true );
+
+    // Theme JavaScript
+    wp_enqueue_script( 'starter-theme', get_template_directory_uri() . '/js/theme.js', array('swiper'), null, true );
+}
+add_action( 'wp_enqueue_scripts', 'starter_theme_scripts' );

--- a/header.php
+++ b/header.php
@@ -6,6 +6,17 @@
     <?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
-<header>
-    <h1><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+<header class="site-header">
+    <div class="site-branding">
+        <h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+    </div>
+    <button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false">Menu</button>
+    <?php
+        wp_nav_menu( array(
+            'theme_location' => 'primary',
+            'menu_id'        => 'primary-menu',
+            'menu_class'     => 'primary-menu',
+            'container'      => 'nav'
+        ) );
+    ?>
 </header>

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,26 @@
+// Initialize Swiper slider if present
+window.addEventListener('DOMContentLoaded', function () {
+    var slider = document.querySelector('.swiper');
+    if (slider && typeof Swiper !== 'undefined') {
+        new Swiper(slider, {
+            loop: true,
+            pagination: {
+                el: '.swiper-pagination',
+                clickable: true
+            },
+            navigation: {
+                nextEl: '.swiper-button-next',
+                prevEl: '.swiper-button-prev'
+            }
+        });
+    }
+
+    // Mobile navigation toggle
+    var toggle = document.querySelector('.menu-toggle');
+    var menu = document.querySelector('#primary-menu');
+    if (toggle && menu) {
+        toggle.addEventListener('click', function () {
+            menu.classList.toggle('toggled');
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -14,3 +14,128 @@ body {
     margin: 0;
     padding: 0;
 }
+
+/* Header and Navigation */
+.site-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    background: #f5f5f5;
+}
+.site-title {
+    margin: 0;
+    font-size: 1.5rem;
+}
+.primary-menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}
+.primary-menu li {
+    margin-left: 1rem;
+}
+.menu-toggle {
+    display: none;
+    background: none;
+    border: 0;
+    font-size: 1rem;
+}
+@media (max-width: 600px) {
+    .primary-menu {
+        display: none;
+        flex-direction: column;
+    }
+    .primary-menu.toggled {
+        display: flex;
+    }
+    .menu-toggle {
+        display: block;
+    }
+}
+
+/* Hero Banner */
+.hero-banner {
+    background: #e9f5ff;
+    text-align: center;
+    padding: 3rem 1rem;
+}
+.hero-banner h2 {
+    margin-top: 0;
+}
+
+/* Offerings Cards */
+.offerings {
+    padding: 2rem 1rem;
+    text-align: center;
+}
+.offerings .cards {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+}
+.offerings .card {
+    background: #fff;
+    border: 1px solid #ddd;
+    padding: 1rem;
+    flex: 1 1 200px;
+}
+
+/* Gallery Slider */
+.animal-gallery {
+    padding: 2rem 1rem;
+}
+.animal-gallery img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+/* Contact Section */
+.contact-section {
+    padding: 2rem 1rem;
+    background: #f9f9f9;
+}
+.contact-form {
+    display: flex;
+    flex-direction: column;
+    max-width: 400px;
+    margin: 0 auto 1rem;
+}
+.contact-form label {
+    margin-top: 0.5rem;
+}
+.contact-form input,
+.contact-form textarea {
+    padding: 0.5rem;
+    margin-top: 0.25rem;
+}
+.contact-form button {
+    margin-top: 1rem;
+    padding: 0.5rem;
+}
+.contact-info {
+    text-align: center;
+}
+
+/* Footer */
+.site-footer {
+    background: #333;
+    color: #fff;
+    text-align: center;
+    padding: 1rem;
+}
+.site-footer .social-links {
+    list-style: none;
+    padding: 0;
+    margin: 0.5rem 0 0;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+}
+.site-footer .social-links a {
+    color: #fff;
+    text-decoration: none;
+}

--- a/templates/front-page.php
+++ b/templates/front-page.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Template Name: Front Page
+ * Description: Custom landing page template for the animal shelter theme.
+ */
+
+get_header();
+?>
+
+<section class="hero-banner">
+    <div class="container">
+        <h2>Welcome to Our Animal Shelter</h2>
+        <p>We provide safe havens for animals and help them find loving homes.</p>
+    </div>
+</section>
+
+<section class="offerings">
+    <h2>What We Offer</h2>
+    <div class="cards">
+        <article class="card">
+            <h3>Adoption</h3>
+            <p>Find your new best friend today.</p>
+        </article>
+        <article class="card">
+            <h3>Volunteer</h3>
+            <p>Join us and make a difference.</p>
+        </article>
+        <article class="card">
+            <h3>Donate</h3>
+            <p>Your support saves lives.</p>
+        </article>
+        <article class="card">
+            <h3>Foster</h3>
+            <p>Provide a temporary home for animals in need.</p>
+        </article>
+    </div>
+</section>
+
+<section class="animal-gallery">
+    <h2>Meet Our Animals</h2>
+    <div class="swiper">
+        <div class="swiper-wrapper">
+            <div class="swiper-slide"><img src="https://via.placeholder.com/600x400" alt="Animal 1"></div>
+            <div class="swiper-slide"><img src="https://via.placeholder.com/600x400" alt="Animal 2"></div>
+            <div class="swiper-slide"><img src="https://via.placeholder.com/600x400" alt="Animal 3"></div>
+        </div>
+        <div class="swiper-pagination"></div>
+        <div class="swiper-button-prev"></div>
+        <div class="swiper-button-next"></div>
+    </div>
+</section>
+
+<section class="contact-section">
+    <h2>Contact Us</h2>
+    <form class="contact-form">
+        <label for="contact-name">Name</label>
+        <input type="text" id="contact-name" name="name" required>
+
+        <label for="contact-email">Email</label>
+        <input type="email" id="contact-email" name="email" required>
+
+        <label for="contact-message">Message</label>
+        <textarea id="contact-message" name="message" rows="5" required></textarea>
+
+        <button type="submit">Send Message</button>
+    </form>
+    <div class="contact-info">
+        <p>123 Shelter Ave, Cityville</p>
+        <p>Email: info@example.com</p>
+        <p>Phone: (555) 555-5555</p>
+    </div>
+</section>
+
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- register primary navigation menu and enqueue Swiper assets
- build responsive header with navigation
- create landing page template with hero banner, offerings cards, slider, contact section
- add JS for slider and mobile navigation
- style new components and footer with social links

## Testing
- `php -l functions.php` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d4635d9ec832f8c0a8f74967e8393