### PR TITLE
Add blog link and image size limits

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -3,6 +3,7 @@
         <ul class="footer-menu">
             <li><a href="#offerings">About Us</a></li>
             <li><a href="<?php echo esc_url( home_url( '/blog-catalog' ) ); ?>">Blog Catalog</a></li>
+            <li><a href="<?php echo esc_url( home_url( '/blog' ) ); ?>">Blog</a></li>
             <li><a href="#contact">Contact Us</a></li>
         </ul>
     </nav>

--- a/header.php
+++ b/header.php
@@ -19,6 +19,7 @@
         <ul id="primary-menu" class="primary-menu">
             <li><a href="#offerings"><span class="dashicons dashicons-info"></span><span class="label">About Us</span></a></li>
             <li><a href="<?php echo esc_url( home_url( '/blog-catalog' ) ); ?>"><span class="dashicons dashicons-admin-post"></span><span class="label">Blog Catalog</span></a></li>
+            <li><a href="<?php echo esc_url( home_url( '/blog' ) ); ?>"><span class="dashicons dashicons-welcome-write-blog"></span><span class="label">Blog</span></a></li>
             <li><a href="#contact"><span class="dashicons dashicons-email"></span><span class="label">Contact Us</span></a></li>
         </ul>
     </nav>

--- a/style.css
+++ b/style.css
@@ -389,11 +389,13 @@ body > section:nth-of-type(even) {
 }
 
 .post-card img {
-    width: 100%;
+    width: auto;
     height: auto;
     max-width: 100%;
     max-height: 220px;
     object-fit: cover;
+    display: block;
+    margin: 0 auto;
 }
 
 .post-card .post-title {

--- a/templates/blog-catalog.php
+++ b/templates/blog-catalog.php
@@ -28,7 +28,7 @@ get_header();
                 <article id="post-<?php the_ID(); ?>" <?php post_class('post-card'); ?>>
                     <?php if ( has_post_thumbnail() ) : ?>
                         <a href="<?php the_permalink(); ?>" class="post-thumbnail">
-                            <?php the_post_thumbnail('large'); ?>
+                            <?php the_post_thumbnail('medium_large'); ?>
                         </a>
                     <?php endif; ?>
                     <h3 class="post-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>


### PR DESCRIPTION
## Summary
- constrain featured image dimensions in blog catalog cards
- show a **Blog** link in header and footer menus
- load medium-sized thumbnails for catalog posts

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_b_684d656e26b0832fb2a8e7e11aac6e19